### PR TITLE
Fixed .NET 6 nullability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -238,7 +238,7 @@ dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.style = pa
 
 dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.severity = suggestion
 dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.symbols = private_static_readonly_fields
-dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.style = _camelcase
 
 dotnet_naming_rule.enums_should_be_pascalcase.severity = suggestion
 dotnet_naming_rule.enums_should_be_pascalcase.symbols = enums

--- a/Minsk/CodeAnalysis/Compilation.cs
+++ b/Minsk/CodeAnalysis/Compilation.cs
@@ -14,7 +14,7 @@ public class Compilation
 
     public SyntaxTree Syntax { get; }
 
-    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables)
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object?> variables)
     {
         var binder = new Binder(variables);
         var boundExpression = binder.BindExpression(Syntax.Root);

--- a/Minsk/CodeAnalysis/Evaluator.cs
+++ b/Minsk/CodeAnalysis/Evaluator.cs
@@ -5,20 +5,20 @@ namespace Minsk.CodeAnalysis;
 internal sealed class Evaluator
 {
     private readonly BoundExpression _root;
-    private readonly Dictionary<VariableSymbol, object> _variables;
+    private readonly Dictionary<VariableSymbol, object?> _variables;
 
-    public Evaluator(BoundExpression root, Dictionary<VariableSymbol, object> variables)
+    public Evaluator(BoundExpression root, Dictionary<VariableSymbol, object?> variables)
     {
         _root = root;
         _variables = variables;
     }
 
-    public object Evaluate()
+    public object? Evaluate()
     {
         return EvaluateExpression(_root);
     }
 
-    private object EvaluateExpression(BoundExpression node)
+    private object? EvaluateExpression(BoundExpression node)
     {
         if (node is BoundLiteralExpression n)
         {
@@ -40,7 +40,10 @@ internal sealed class Evaluator
         if (node is BoundUnaryExpression u)
         {
             var operand = EvaluateExpression(u.Operand);
-            return u.Op.Kind switch
+
+            return operand == null
+            ? null
+            : u.Op.Kind switch
             {
                 BoundUnaryOperatorKind.Identity => (int)operand,
                 BoundUnaryOperatorKind.Negation => -(int)operand,
@@ -53,8 +56,9 @@ internal sealed class Evaluator
         {
             var left = EvaluateExpression(b.Left);
             var right = EvaluateExpression(b.Right);
-
-            return b.Op.Kind switch
+            return left == null || right == null
+            ? null
+            : b.Op.Kind switch
             {
                 BoundBinaryOperatorKind.Addition => (int)left + (int)right,
                 BoundBinaryOperatorKind.Subtraction => (int)left - (int)right,

--- a/Minsk/CodeAnalysis/Syntax/Lexer.cs
+++ b/Minsk/CodeAnalysis/Syntax/Lexer.cs
@@ -125,10 +125,8 @@ internal sealed class Lexer
     private char Peek(int offset)
     {
         var index = _position + offset;
-        if (index >= _text.Length)
-        {
-            return '\0';
-        }
-        return _text[index];
+        return index >= _text.Length
+             ? '\0'
+             : _text[index];
     }
 }

--- a/Minsk/CodeAnalysis/Syntax/Parser.cs
+++ b/Minsk/CodeAnalysis/Syntax/Parser.cs
@@ -151,10 +151,8 @@ internal sealed class Parser
     private SyntaxToken Peek(int offset)
     {
         var index = _position + offset;
-        if (index >= _tokens.Length)
-        {
-            return _tokens[^1];
-        }
-        return _tokens[index];
+        return index >= _tokens.Length
+             ? _tokens[^1]
+             : _tokens[index];
     }
 }


### PR DESCRIPTION
Fixed the nullability of the variables dictionary that wasn't correctly representing the nullability of its values. Also updated the .editorconfig file to use the correct naming convention for private static readonly fields.